### PR TITLE
Fix tasks that last>1s started every second

### DIFF
--- a/task/task.go
+++ b/task/task.go
@@ -44,14 +44,13 @@ func (task *Task) IsDue() bool {
 }
 
 func (task *Task) Run() {
+	task.scheduleNextRun()
 	function := reflect.ValueOf(task.Func.function)
 	params := make([]reflect.Value, len(task.Params))
 	for i, param := range task.Params {
 		params[i] = reflect.ValueOf(param)
 	}
 	function.Call(params)
-
-	task.scheduleNextRun()
 }
 
 func (task *Task) Hash() TaskID {


### PR DESCRIPTION
Simple test application:
```
package main

import (
        "log"
        "time"
        "github.com/rakanalh/scheduler"
        "github.com/rakanalh/scheduler/storage"
)

func TaskWithoutArgs() {
        log.Println("TaskWithoutArgs is executed")
        time.Sleep(5*time.Second)
        log.Println("TaskWithoutArgs is ended")
}

func main() {
        s := scheduler.New(storage.NewMemoryStorage())
        s.RunEvery(5*time.Second, TaskWithoutArgs)
        s.Start()
        s.Wait()
}
```


Output showing TaskWithoutArgs  running every 1s instead of 5s:

```
2017/11/20 03:19:46 Scheduler is starting...
2017/11/20 03:19:51 TaskWithoutArgs is executed
2017/11/20 03:19:52 TaskWithoutArgs is executed
2017/11/20 03:19:53 TaskWithoutArgs is executed
2017/11/20 03:19:54 TaskWithoutArgs is executed
2017/11/20 03:19:55 TaskWithoutArgs is executed
2017/11/20 03:19:56 TaskWithoutArgs is executed
2017/11/20 03:19:56 TaskWithoutArgs is ended
2017/11/20 03:19:57 TaskWithoutArgs is executed
2017/11/20 03:19:57 TaskWithoutArgs is ended
2017/11/20 03:19:58 TaskWithoutArgs is ended
2017/11/20 03:19:59 TaskWithoutArgs is ended
2017/11/20 03:20:00 TaskWithoutArgs is ended
2017/11/20 03:20:01 TaskWithoutArgs is ended
2017/11/20 03:20:02 TaskWithoutArgs is ended

2017/11/20 03:20:26 TaskWithoutArgs is executed
2017/11/20 03:20:27 TaskWithoutArgs is executed
2017/11/20 03:20:28 TaskWithoutArgs is executed
2017/11/20 03:20:29 TaskWithoutArgs is executed
2017/11/20 03:20:30 TaskWithoutArgs is executed
2017/11/20 03:20:31 TaskWithoutArgs is executed
2017/11/20 03:20:31 TaskWithoutArgs is ended
2017/11/20 03:20:32 TaskWithoutArgs is executed
2017/11/20 03:20:32 TaskWithoutArgs is ended
2017/11/20 03:20:33 TaskWithoutArgs is ended
2017/11/20 03:20:34 TaskWithoutArgs is ended
2017/11/20 03:20:35 TaskWithoutArgs is ended
2017/11/20 03:20:36 TaskWithoutArgs is ended
2017/11/20 03:20:37 TaskWithoutArgs is ended

```


After applying fix:
```
go run main.go
2017/11/20 03:25:44 Scheduler is starting...
2017/11/20 03:25:49 TaskWithoutArgs is executed
2017/11/20 03:25:54 TaskWithoutArgs is executed
2017/11/20 03:25:54 TaskWithoutArgs is ended
2017/11/20 03:25:59 TaskWithoutArgs is executed
2017/11/20 03:25:59 TaskWithoutArgs is ended
2017/11/20 03:26:04 TaskWithoutArgs is ended
2017/11/20 03:26:04 TaskWithoutArgs is executed
2017/11/20 03:26:09 TaskWithoutArgs is executed
2017/11/20 03:26:09 TaskWithoutArgs is ended
```
