### PR TITLE
return err instead of nil on errors, so we can check for err != nil on scheduler start

### DIFF
--- a/scheduler.go
+++ b/scheduler.go
@@ -72,10 +72,10 @@ func (scheduler *Scheduler) Start() error {
 
 	// Populate tasks from storage
 	if err := scheduler.populateTasks(); err != nil {
-		return nil
+		return err
 	}
 	if err := scheduler.persistRegisteredTasks(); err != nil {
-		return nil
+		return err
 	}
 	scheduler.runPending()
 


### PR DESCRIPTION
```
        err = s.Start()
        if err != nil {
            log.Fatal(err)
        }
```